### PR TITLE
Stylings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,9 @@ name = "serde"
 version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1283,7 +1286,6 @@ dependencies = [
  "gstreamer",
  "gstreamer-video",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ gstreamer = { version = "0.16.3", features = ["v1_14"]}
 gstreamer-video = "0.16.3"
 tokio = { version = "0.2", features = ["full"] }
 warp = "0.2"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 thiserror = "1.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,10 @@
-use switcher::http::Server;
-extern crate gstreamer as gst;
+mod http;
+mod input;
+mod mixer;
+mod output;
+
+use gstreamer as gst;
+use http::Server;
 
 // TODO: Bring in Clap for command line arguments
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,8 +1,5 @@
-extern crate serde;
-extern crate serde_derive;
-
 use crate::mixer;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/src/mixer/input.rs
+++ b/src/mixer/input.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use gst::prelude::*;
+use gstreamer as gst;
 
 pub enum Input {
     URI(URI),

--- a/src/mixer/output.rs
+++ b/src/mixer/output.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 use gst::prelude::*;
+use gstreamer as gst;
 
 pub enum Output {
     RTMP(RTMP),


### PR DESCRIPTION
Hi, I removed the `extern crate` imports as they are no longer necessary [https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html#no-more-extern-crate](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html#no-more-extern-crate).
I also removed serde derive as a direct dependency and added it as a feature for serde, see https://serde.rs/derive.html